### PR TITLE
Add github action - check markdown links

### DIFF
--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -1,0 +1,32 @@
+name: Markdown Linter
+on: [push, pull_request]
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  lint:
+    name: Markdown
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14
+      - name: Setup Linter
+        # Do not forget to add new linters to ../../.remarkrc
+        run: "npm install --global remark-cli remark-validate-links remark-lint-no-dead-urls"
+      - name: Lint
+        run: "remark -f ."
+
+# TODO:
+#   - linter: install remark-preset-lint-recommended and run it
+#             or use some preset from links below
+#   - add -o to Lint/run to actually fix files and add commit step
+# LINKS:
+#   - markdown lint presets
+#     - https://github.com/topics/remark-preset
+#     - https://www.npmjs.com/search?q=remark-preset
+#   - more plugins: https://github.com/remarkjs/remark/blob/HEAD/doc/plugins.md#list-of-plugins

--- a/.remarkrc
+++ b/.remarkrc
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    "validate-links",
+    [ "lint-no-dead-urls", { "skipUrlPatterns": [ "https://github.com/orgs/mayadata-io/projects/2" ] } ]
+  ]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-Welcome to MayaData. We are excited about the prospect of you joining us! We abide by the values outlined in [PLOW](https://github.com/mayadata-io/culture/blob/master/plow.md), which is a superset of generally accepted [code of conduct](CODE-OF-CONDUCT.md).
+Welcome to MayaData. We are excited about the prospect of you joining us! We abide by the values outlined in [PLOW](https://github.com/mayadata-io/culture/blob/master/plow.md), which is a superset of generally accepted [code of conduct](CODE_OF_CONDUCT.md).
 
 We use the standard GitHub pull requests process to review and accept contributions to this repository. 
 

--- a/process/developer-advocacy.md
+++ b/process/developer-advocacy.md
@@ -17,7 +17,7 @@ Meghan Gill, former developer marketing leader at MongoDB and current VP of Sale
 
 ## Who can be a Developer Advocate?
 
-Everybody in wider MayaData Community can be a Developer Advocate. Whether you work in marketing, ops or engineering, you have a point of view on the work you do and the ecosystem of open source enterprise technology. If you are looking for ideas to get started, reach out on #dac slack channel or look for open items under [Community Interactions project](https://github.com/orgs/mayadata-io/projects/2). 
+Everybody in wider MayaData Community can be a Developer Advocate. Whether you work in marketing, ops or engineering, you have a point of view on the work you do and the ecosystem of open source enterprise technology. If you are looking for ideas to get started, reach out on #dac slack channel or look for open items under [Community Interactions project](https://github.com/orgs/mayadata-io/projects/2)(_internal link_).
 
 ## Stages of Developer Advocacy
 - Beginner - when you start following the right accounts on Twitter, peruse HN regularly, and respond to people

--- a/process/marketing.md
+++ b/process/marketing.md
@@ -11,7 +11,7 @@ Here are some guidelines on what we think are the driving principles of a good O
 - [OpenSource is the way to go](#opensource-is-the-way-to-go)
 - [Be where the users are](#be-where-the-users-are)
 - [Support Open Source communities](#support-open-source-communities)
-- [Anonymous community growth is important](#snonymous-community-growth-is-important)
+- [Anonymous community growth is important](#anonymous-community-growth-is-important)
 - [All user feedback is valuable](#all-user-feedback-is-valuable)
 - [Focus on what users need](#focus-on-what-users-need)
 - [Help users advance their knowledge](#help-users-advance-their-knowledge)


### PR DESCRIPTION
To help keeping culture repo usable without too much hassle, let's add some gitlab actions.

This uses powerful looking markdown linting/fixing framework https://github.com/remarkjs/remark

One of our links is internal. I would recommend not using internal links in public repo, but for now I have whitelisted it in `.remarkrc` and tagged the link as internal in the text to avoid looking dead from outside.