### PR TITLE
tools/subscriptions: update slack channel link

### DIFF
--- a/tools/subscriptions.md
+++ b/tools/subscriptions.md
@@ -1,6 +1,6 @@
 The page contains the list of Software tools, IDE etc that people at MayaData use in order to be productive at their job.
 
-If you would like access to any of the following tools or would like to suggest purchasing or subscribing a new tool, please reach out on the MayaData Slack channel [#purchased_tools](https://mayadata-team.slack.com/messages/purchased_tools)
+If you would like access to any of the following tools or would like to suggest purchasing or subscribing a new tool, please reach out on the MayaData Slack channel [#ask](https://mayadata-team.slack.com/messages/ask).
 
 * [GoLand](https://www.jetbrains.com/go/)
   - Go Editor/IDE


### PR DESCRIPTION
Channel #purchased_tools has been archived and no longer exists.