### PR TITLE
book.toml: specify which branch we use as default

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -17,6 +17,7 @@ command = "mdbook-toc"
 renderer = ["html"]
 
 [output.html]
+git-branch = "master"
 git-repository-url = "https://github.com/mayadata-io/culture"
 additional-css = ["css/open-in.css"]
 cname = "culture.mayadata.io"


### PR DESCRIPTION
Edit on github links on pages made by open-on-gh preprocessor expect `main` branch.
We have `master`

Another possibility is to swtich to `main` default branch.